### PR TITLE
ensure pdflatex processing for arXiv submission

### DIFF
--- a/WSSSPE2_report/WSSSPE2_review.tex
+++ b/WSSSPE2_report/WSSSPE2_review.tex
@@ -1,4 +1,5 @@
 \documentclass[11pt, oneside]{amsart}
+\pdfoutput=1
 
 \usepackage{amsmath}
 \usepackage{amssymb}


### PR DESCRIPTION
This solves the problem of line overflow in URLs in the bibliography produced by `latex`.